### PR TITLE
Replaced ALL occurences of de.danoeh.antennapod with de.danoeh.antennapod_mh

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -119,7 +119,7 @@
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="de.danoeh.antennapod.FORCE_WIDGET_UPDATE"/>
+                <action android:name="de.danoeh.antennapod_mh.FORCE_WIDGET_UPDATE"/>
             </intent-filter>
 
             <meta-data
@@ -127,7 +127,7 @@
                 android:resource="@xml/player_widget_info"/>
 
             <intent-filter>
-                <action android:name="de.danoeh.antennapod.STOP_WIDGET_UPDATE"/>
+                <action android:name="de.danoeh.antennapod_mh.STOP_WIDGET_UPDATE"/>
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/de/danoeh/antennapod_mh/activity/FeedInfoActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod_mh/activity/FeedInfoActivity.java
@@ -57,7 +57,7 @@ import rx.schedulers.Schedulers;
  */
 public class FeedInfoActivity extends AppCompatActivity {
 
-    public static final String EXTRA_FEED_ID = "de.danoeh.antennapod.extra.feedId";
+    public static final String EXTRA_FEED_ID = "de.danoeh.antennapod_mh.extra.feedId";
     private static final String TAG = "FeedInfoActivity";
     private boolean autoDeleteChanged = false;
     private Feed feed;

--- a/app/src/main/java/de/danoeh/antennapod_mh/activity/OpmlFeedChooserActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod_mh/activity/OpmlFeedChooserActivity.java
@@ -23,7 +23,7 @@ import de.danoeh.antennapod_mh.core.preferences.UserPreferences;
  * which feeds he wants to import.
  */
 public class OpmlFeedChooserActivity extends AppCompatActivity {
-    public static final String EXTRA_SELECTED_ITEMS = "de.danoeh.antennapod.selectedItems";
+    public static final String EXTRA_SELECTED_ITEMS = "de.danoeh.antennapod_mh.selectedItems";
     private static final String TAG = "OpmlFeedChooserActivity";
     private Button butConfirm;
     private Button butCancel;

--- a/app/src/main/java/de/danoeh/antennapod_mh/fragment/ItemlistFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod_mh/fragment/ItemlistFragment.java
@@ -86,8 +86,8 @@ public class ItemlistFragment extends ListFragment {
             | EventDistributor.FEED_LIST_UPDATE
             | EventDistributor.PLAYER_STATUS_UPDATE;
 
-    public static final String EXTRA_SELECTED_FEEDITEM = "extra.de.danoeh.antennapod.activity.selected_feeditem";
-    private static final String ARGUMENT_FEED_ID = "argument.de.danoeh.antennapod.feed_id";
+    public static final String EXTRA_SELECTED_FEEDITEM = "extra.de.danoeh.antennapod_mh.activity.selected_feeditem";
+    private static final String ARGUMENT_FEED_ID = "argument.de.danoeh.antennapod_mh.feed_id";
 
     private FeedItemlistAdapter adapter;
     private ContextMenu contextMenu;

--- a/app/src/main/java/de/danoeh/antennapod_mh/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod_mh/preferences/PreferenceController.java
@@ -479,7 +479,7 @@ public class PreferenceController implements SharedPreferences.OnSharedPreferenc
                     alert.setMessage(message);
                     alert.setPositiveButton(R.string.send_label, (dialog, which) -> {
                         Uri fileUri = FileProvider.getUriForFile(context.getApplicationContext(),
-                                "de.danoeh.antennapod.provider", output);
+                                "de.danoeh.antennapod_mh.provider", output);
                         Intent sendIntent = new Intent(Intent.ACTION_SEND);
                         sendIntent.putExtra(Intent.EXTRA_SUBJECT,
                                 context.getResources().getText(R.string.opml_export_label));

--- a/app/src/main/res/menu/cast_enabled.xml
+++ b/app/src/main/res/menu/cast_enabled.xml
@@ -5,6 +5,6 @@
     <item
         android:id="@+id/media_route_menu_item"
         android:title="@string/cast_media_route_menu_title"
-        custom:actionProviderClass="de.danoeh.antennapod.core.cast.SwitchableMediaRouteActionProvider"
+        custom:actionProviderClass="de.danoeh.antennapod_mh.core.cast.SwitchableMediaRouteActionProvider"
         custom:showAsAction="ifRoom"/>
 </menu>

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,8 +10,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-        testApplicationId "de.danoeh.antennapod.core.tests"
-        testInstrumentationRunner "de.danoeh.antennapod.core.tests.AntennaPodTestRunner"
+        testApplicationId "de.danoeh.antennapod_mh.core.tests"
+        testInstrumentationRunner "de.danoeh.antennapod_mh.core.tests.AntennaPodTestRunner"
     }
     buildTypes {
         release {

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -36,7 +36,7 @@
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>
             <intent-filter>
-                <action android:name="de.danoeh.antennapod.NOTIFY_BUTTON_RECEIVER" />
+                <action android:name="de.danoeh.antennapod_mh.NOTIFY_BUTTON_RECEIVER" />
             </intent-filter>
         </receiver>
 

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/preferences/GpodnetPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/preferences/GpodnetPreferences.java
@@ -27,19 +27,19 @@ public class GpodnetPreferences {
     private static final String TAG = "GpodnetPreferences";
 
     private static final String PREF_NAME = "gpodder.net";
-    private static final String PREF_GPODNET_USERNAME = "de.danoeh.antennapod.preferences.gpoddernet.username";
-    private static final String PREF_GPODNET_PASSWORD = "de.danoeh.antennapod.preferences.gpoddernet.password";
-    private static final String PREF_GPODNET_DEVICEID = "de.danoeh.antennapod.preferences.gpoddernet.deviceID";
+    private static final String PREF_GPODNET_USERNAME = "de.danoeh.antennapod_mh.preferences.gpoddernet.username";
+    private static final String PREF_GPODNET_PASSWORD = "de.danoeh.antennapod_mh.preferences.gpoddernet.password";
+    private static final String PREF_GPODNET_DEVICEID = "de.danoeh.antennapod_mh.preferences.gpoddernet.deviceID";
     private static final String PREF_GPODNET_HOSTNAME = "prefGpodnetHostname";
 
 
-    private static final String PREF_LAST_SUBSCRIPTION_SYNC_TIMESTAMP = "de.danoeh.antennapod.preferences.gpoddernet.last_sync_timestamp";
-    private static final String PREF_LAST_EPISODE_ACTIONS_SYNC_TIMESTAMP = "de.danoeh.antennapod.preferences.gpoddernet.last_episode_actions_sync_timestamp";
-    private static final String PREF_SYNC_ADDED = "de.danoeh.antennapod.preferences.gpoddernet.sync_added";
-    private static final String PREF_SYNC_REMOVED = "de.danoeh.antennapod.preferences.gpoddernet.sync_removed";
-    private static final String PREF_SYNC_EPISODE_ACTIONS = "de.danoeh.antennapod.preferences.gpoddernet.sync_queued_episode_actions";
-    public static final String PREF_LAST_SYNC_ATTEMPT_TIMESTAMP = "de.danoeh.antennapod.preferences.gpoddernet.last_sync_attempt_timestamp";
-    private static final String PREF_LAST_SYNC_ATTEMPT_RESULT = "de.danoeh.antennapod.preferences.gpoddernet.last_sync_attempt_result";
+    private static final String PREF_LAST_SUBSCRIPTION_SYNC_TIMESTAMP = "de.danoeh.antennapod_mh.preferences.gpoddernet.last_sync_timestamp";
+    private static final String PREF_LAST_EPISODE_ACTIONS_SYNC_TIMESTAMP = "de.danoeh.antennapod_mh.preferences.gpoddernet.last_episode_actions_sync_timestamp";
+    private static final String PREF_SYNC_ADDED = "de.danoeh.antennapod_mh.preferences.gpoddernet.sync_added";
+    private static final String PREF_SYNC_REMOVED = "de.danoeh.antennapod_mh.preferences.gpoddernet.sync_removed";
+    private static final String PREF_SYNC_EPISODE_ACTIONS = "de.danoeh.antennapod_mh.preferences.gpoddernet.sync_queued_episode_actions";
+    public static final String PREF_LAST_SYNC_ATTEMPT_TIMESTAMP = "de.danoeh.antennapod_mh.preferences.gpoddernet.last_sync_attempt_timestamp";
+    private static final String PREF_LAST_SYNC_ATTEMPT_RESULT = "de.danoeh.antennapod_mh.preferences.gpoddernet.last_sync_attempt_result";
 
     private static String username;
     private static String password;

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/preferences/PlaybackPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/preferences/PlaybackPreferences.java
@@ -19,35 +19,35 @@ public class PlaybackPreferences implements SharedPreferences.OnSharedPreference
      * Contains the feed id of the currently playing item if it is a FeedMedia
      * object.
      */
-    public static final String PREF_CURRENTLY_PLAYING_FEED_ID = "de.danoeh.antennapod.preferences.lastPlayedFeedId";
+    public static final String PREF_CURRENTLY_PLAYING_FEED_ID = "de.danoeh.antennapod_mh.preferences.lastPlayedFeedId";
 
     /**
      * Contains the id of the currently playing FeedMedia object or
      * NO_MEDIA_PLAYING if the currently playing media is no FeedMedia object.
      */
-    public static final String PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID = "de.danoeh.antennapod.preferences.lastPlayedFeedMediaId";
+    public static final String PREF_CURRENTLY_PLAYING_FEEDMEDIA_ID = "de.danoeh.antennapod_mh.preferences.lastPlayedFeedMediaId";
 
     /**
      * Type of the media object that is currently being played. This preference
      * is set to NO_MEDIA_PLAYING after playback has been completed and is set
      * as soon as the 'play' button is pressed.
      */
-    public static final String PREF_CURRENTLY_PLAYING_MEDIA = "de.danoeh.antennapod.preferences.currentlyPlayingMedia";
+    public static final String PREF_CURRENTLY_PLAYING_MEDIA = "de.danoeh.antennapod_mh.preferences.currentlyPlayingMedia";
 
     /**
      * True if last played media was streamed.
      */
-    public static final String PREF_CURRENT_EPISODE_IS_STREAM = "de.danoeh.antennapod.preferences.lastIsStream";
+    public static final String PREF_CURRENT_EPISODE_IS_STREAM = "de.danoeh.antennapod_mh.preferences.lastIsStream";
 
     /**
      * True if last played media was a video.
      */
-    public static final String PREF_CURRENT_EPISODE_IS_VIDEO = "de.danoeh.antennapod.preferences.lastIsVideo";
+    public static final String PREF_CURRENT_EPISODE_IS_VIDEO = "de.danoeh.antennapod_mh.preferences.lastIsVideo";
 
     /**
      * The current player status as int.
      */
-    public static final String PREF_CURRENT_PLAYER_STATUS = "de.danoeh.antennapod.preferences.currentPlayerStatus";
+    public static final String PREF_CURRENT_PLAYER_STATUS = "de.danoeh.antennapod_mh.preferences.currentPlayerStatus";
 
     /**
      * Value of PREF_CURRENTLY_PLAYING_MEDIA if no media is playing.

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/receiver/MediaButtonReceiver.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/receiver/MediaButtonReceiver.java
@@ -12,10 +12,10 @@ import de.danoeh.antennapod_mh.core.service.playback.PlaybackService;
 /** Receives media button events. */
 public class MediaButtonReceiver extends BroadcastReceiver {
 	private static final String TAG = "MediaButtonReceiver";
-	public static final String EXTRA_KEYCODE = "de.danoeh.antennapod.core.service.extra.MediaButtonReceiver.KEYCODE";
-	public static final String EXTRA_SOURCE = "de.danoeh.antennapod.core.service.extra.MediaButtonReceiver.SOURCE";
+	public static final String EXTRA_KEYCODE = "de.danoeh.antennapod_mh.core.service.extra.MediaButtonReceiver.KEYCODE";
+	public static final String EXTRA_SOURCE = "de.danoeh.antennapod_mh.core.service.extra.MediaButtonReceiver.SOURCE";
 
-	public static final String NOTIFY_BUTTON_RECEIVER = "de.danoeh.antennapod.NOTIFY_BUTTON_RECEIVER";
+	public static final String NOTIFY_BUTTON_RECEIVER = "de.danoeh.antennapod_mh.NOTIFY_BUTTON_RECEIVER";
 
 	@Override
 	public void onReceive(Context context, Intent intent) {

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/service/GpodnetSyncService.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/service/GpodnetSyncService.java
@@ -49,9 +49,9 @@ public class GpodnetSyncService extends Service {
 
     private static final String ARG_ACTION = "action";
 
-    private static final String ACTION_SYNC = "de.danoeh.antennapod.intent.action.sync";
-    private static final String ACTION_SYNC_SUBSCRIPTIONS = "de.danoeh.antennapod.intent.action.sync_subscriptions";
-    private static final String ACTION_SYNC_ACTIONS = "de.danoeh.antennapod.intent.action.sync_ACTIONS";
+    private static final String ACTION_SYNC = "de.danoeh.antennapod_mh.intent.action.sync";
+    private static final String ACTION_SYNC_SUBSCRIPTIONS = "de.danoeh.antennapod_mh.intent.action.sync_subscriptions";
+    private static final String ACTION_SYNC_ACTIONS = "de.danoeh.antennapod_mh.intent.action.sync_ACTIONS";
 
     private GpodnetService service;
 

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/service/download/DownloadService.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/service/download/DownloadService.java
@@ -92,12 +92,12 @@ public class DownloadService extends Service {
      * Cancels one download. The intent MUST have an EXTRA_DOWNLOAD_URL extra that contains the download URL of the
      * object whose download should be cancelled.
      */
-    public static final String ACTION_CANCEL_DOWNLOAD = "action.de.danoeh.antennapod.core.service.cancelDownload";
+    public static final String ACTION_CANCEL_DOWNLOAD = "action.de.danoeh.antennapod_mh.core.service.cancelDownload";
 
     /**
      * Cancels all running downloads.
      */
-    public static final String ACTION_CANCEL_ALL_DOWNLOADS = "action.de.danoeh.antennapod.core.service.cancelAllDownloads";
+    public static final String ACTION_CANCEL_ALL_DOWNLOADS = "action.de.danoeh.antennapod_mh.core.service.cancelAllDownloads";
 
     /**
      * Extra for ACTION_CANCEL_DOWNLOAD

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/service/playback/PlaybackService.java
@@ -74,8 +74,8 @@ import de.greenrobot.event.EventBus;
  * Controls the MediaPlayer that plays a FeedMedia-file
  */
 public class PlaybackService extends MediaBrowserServiceCompat {
-    public static final String FORCE_WIDGET_UPDATE = "de.danoeh.antennapod.FORCE_WIDGET_UPDATE";
-    public static final String STOP_WIDGET_UPDATE = "de.danoeh.antennapod.STOP_WIDGET_UPDATE";
+    public static final String FORCE_WIDGET_UPDATE = "de.danoeh.antennapod_mh.FORCE_WIDGET_UPDATE";
+    public static final String STOP_WIDGET_UPDATE = "de.danoeh.antennapod_mh.STOP_WIDGET_UPDATE";
     /**
      * Logging tag
      */
@@ -88,56 +88,56 @@ public class PlaybackService extends MediaBrowserServiceCompat {
     /**
      * True if cast session should disconnect.
      */
-    private static final String EXTRA_CAST_DISCONNECT = "extra.de.danoeh.antennapod.core.service.castDisconnect";
+    private static final String EXTRA_CAST_DISCONNECT = "extra.de.danoeh.antennapod_mh.core.service.castDisconnect";
     /**
      * True if media should be streamed.
      */
-    public static final String EXTRA_SHOULD_STREAM = "extra.de.danoeh.antennapod.core.service.shouldStream";
+    public static final String EXTRA_SHOULD_STREAM = "extra.de.danoeh.antennapod_mh.core.service.shouldStream";
     /**
      * True if playback should be started immediately after media has been
      * prepared.
      */
-    public static final String EXTRA_START_WHEN_PREPARED = "extra.de.danoeh.antennapod.core.service.startWhenPrepared";
+    public static final String EXTRA_START_WHEN_PREPARED = "extra.de.danoeh.antennapod_mh.core.service.startWhenPrepared";
 
-    public static final String EXTRA_PREPARE_IMMEDIATELY = "extra.de.danoeh.antennapod.core.service.prepareImmediately";
+    public static final String EXTRA_PREPARE_IMMEDIATELY = "extra.de.danoeh.antennapod_mh.core.service.prepareImmediately";
 
-    public static final String ACTION_PLAYER_STATUS_CHANGED = "action.de.danoeh.antennapod.core.service.playerStatusChanged";
-    public static final String EXTRA_NEW_PLAYER_STATUS = "extra.de.danoeh.antennapod.service.playerStatusChanged.newStatus";
+    public static final String ACTION_PLAYER_STATUS_CHANGED = "action.de.danoeh.antennapod_mh.core.service.playerStatusChanged";
+    public static final String EXTRA_NEW_PLAYER_STATUS = "extra.de.danoeh.antennapod_mh.service.playerStatusChanged.newStatus";
     private static final String AVRCP_ACTION_PLAYER_STATUS_CHANGED = "com.android.music.playstatechanged";
     private static final String AVRCP_ACTION_META_CHANGED = "com.android.music.metachanged";
 
-    public static final String ACTION_PLAYER_NOTIFICATION = "action.de.danoeh.antennapod.core.service.playerNotification";
-    public static final String EXTRA_NOTIFICATION_CODE = "extra.de.danoeh.antennapod.core.service.notificationCode";
-    public static final String EXTRA_NOTIFICATION_TYPE = "extra.de.danoeh.antennapod.core.service.notificationType";
+    public static final String ACTION_PLAYER_NOTIFICATION = "action.de.danoeh.antennapod_mh.core.service.playerNotification";
+    public static final String EXTRA_NOTIFICATION_CODE = "extra.de.danoeh.antennapod_mh.core.service.notificationCode";
+    public static final String EXTRA_NOTIFICATION_TYPE = "extra.de.danoeh.antennapod_mh.core.service.notificationType";
 
     /**
      * If the PlaybackService receives this action, it will stop playback and
      * try to shutdown.
      */
-    public static final String ACTION_SHUTDOWN_PLAYBACK_SERVICE = "action.de.danoeh.antennapod.core.service.actionShutdownPlaybackService";
+    public static final String ACTION_SHUTDOWN_PLAYBACK_SERVICE = "action.de.danoeh.antennapod_mh.core.service.actionShutdownPlaybackService";
 
     /**
      * If the PlaybackService receives this action, it will end playback of the
      * current episode and load the next episode if there is one available.
      */
-    public static final String ACTION_SKIP_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.skipCurrentEpisode";
+    public static final String ACTION_SKIP_CURRENT_EPISODE = "action.de.danoeh.antennapod_mh.core.service.skipCurrentEpisode";
 
     /**
      * If the PlaybackService receives this action, it will pause playback.
      */
-    public static final String ACTION_PAUSE_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.pausePlayCurrentEpisode";
+    public static final String ACTION_PAUSE_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod_mh.core.service.pausePlayCurrentEpisode";
 
 
     /**
      * If the PlaybackService receives this action, it will resume playback.
      */
-    public static final String ACTION_RESUME_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod.core.service.resumePlayCurrentEpisode";
+    public static final String ACTION_RESUME_PLAY_CURRENT_EPISODE = "action.de.danoeh.antennapod_mh.core.service.resumePlayCurrentEpisode";
 
     /**
      * Custom action used by Android Wear
      */
-    private static final String CUSTOM_ACTION_FAST_FORWARD = "action.de.danoeh.antennapod.core.service.fastForward";
-    private static final String CUSTOM_ACTION_REWIND = "action.de.danoeh.antennapod.core.service.rewind";
+    private static final String CUSTOM_ACTION_FAST_FORWARD = "action.de.danoeh.antennapod_mh.core.service.fastForward";
+    private static final String CUSTOM_ACTION_REWIND = "action.de.danoeh.antennapod_mh.core.service.rewind";
 
 
     /**

--- a/core/src/main/java/de/danoeh/antennapod_mh/core/util/flattr/FlattrUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod_mh/core/util/flattr/FlattrUtils.java
@@ -38,7 +38,7 @@ public class FlattrUtils {
 
     private static final String HOST_NAME = "de.danoeh.antennapod";
 
-    private static final String PREF_ACCESS_TOKEN = "de.danoeh.antennapod.preference.flattrAccessToken";
+    private static final String PREF_ACCESS_TOKEN = "de.danoeh.antennapod_mh.preference.flattrAccessToken";
 
     private static volatile AccessToken cachedToken;
 

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
 
     <!-- Activitiy and fragment titles -->
     <string name="app_name" translate="false">AntennaPod</string>
-    <string name="provider_authority" translate="false">de.danoeh.antennapod.provider</string>
+    <string name="provider_authority" translate="false">de.danoeh.antennapod_mh.provider</string>
     <string name="feeds_label">Feeds</string>
     <string name="statistics_label">Statistics</string>
     <string name="add_feed_label">Add Podcast</string>

--- a/core/src/play/java/de/danoeh/antennapod/core/cast/CastUtils.java
+++ b/core/src/play/java/de/danoeh/antennapod/core/cast/CastUtils.java
@@ -26,13 +26,13 @@ import de.danoeh.antennapod_mh.core.util.playback.Playable;
 public class CastUtils {
     private static final String TAG = "CastUtils";
 
-    public static final String KEY_MEDIA_ID = "de.danoeh.antennapod.core.cast.MediaId";
+    public static final String KEY_MEDIA_ID = "de.danoeh.antennapod_mh.core.cast.MediaId";
 
-    public static final String KEY_EPISODE_IDENTIFIER = "de.danoeh.antennapod.core.cast.EpisodeId";
-    public static final String KEY_EPISODE_LINK = "de.danoeh.antennapod.core.cast.EpisodeLink";
-    public static final String KEY_FEED_URL = "de.danoeh.antennapod.core.cast.FeedUrl";
-    public static final String KEY_FEED_WEBSITE = "de.danoeh.antennapod.core.cast.FeedWebsite";
-    public static final String KEY_EPISODE_NOTES = "de.danoeh.antennapod.core.cast.EpisodeNotes";
+    public static final String KEY_EPISODE_IDENTIFIER = "de.danoeh.antennapod_mh.core.cast.EpisodeId";
+    public static final String KEY_EPISODE_LINK = "de.danoeh.antennapod_mh.core.cast.EpisodeLink";
+    public static final String KEY_FEED_URL = "de.danoeh.antennapod_mh.core.cast.FeedUrl";
+    public static final String KEY_FEED_WEBSITE = "de.danoeh.antennapod_mh.core.cast.FeedWebsite";
+    public static final String KEY_EPISODE_NOTES = "de.danoeh.antennapod_mh.core.cast.EpisodeNotes";
     public static final int EPISODE_NOTES_MAX_LENGTH = Integer.MAX_VALUE;
 
     /**
@@ -44,7 +44,7 @@ public class CastUtils {
      * <code>MAX_VERSION_FORWARD_COMPATIBILITY</code> value set on the earlier one, so that it
      * doesn't try to parse the object.
      */
-    public static final String KEY_FORMAT_VERSION = "de.danoeh.antennapod.core.cast.FormatVersion";
+    public static final String KEY_FORMAT_VERSION = "de.danoeh.antennapod_mh.core.cast.FormatVersion";
     public static final int FORMAT_VERSION_VALUE = 1;
     public static final int MAX_VERSION_FORWARD_COMPATIBILITY = 9999;
 


### PR DESCRIPTION
Just a simple global search/replace.
There were dozens on unreplaced references.

I built the result on AndroidStudio, and successfully managed to run on my phone, the one that had collisions with the bare app (Error 505) on the play store app.

hehe, I hope this is a bypass to cut through the queue at your email backlog :-)

Please check this carefully, it might cause older settings to be lost :-(
